### PR TITLE
aanpassen aan acpaas ui vnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,21 +100,17 @@ Je gebruikt de recentste versie van de A-kit (core branding). Om een idee te kri
 
 Alle broncode van de digitale componenten is tevens terug te vinden op GitHub: https://github.com/a-ui/core_branding_scss [**publiek**]. Hier kunnen ontwikkelaars de broncode bekijken, zelf verbeteringen voorstellen of eventuele bugs inseinen.
 
-#### 2.2.3. Guidelines (**V**)
-Alle frontend programmatie dient te gebeuren conform de guidelines: 
-https://acpaas-ui.digipolis.be/docs/guidelines [**MW**].
+#### 2.2.3. Component bibliotheek (**V**)
+Er is een gebruiksklare bibliotheek beschikbaar met de meestgebruikte UI componenten in de laatste stabiele Angular en React versies. Alle componenten worden gepubliceerd op https://npmjs.com [**publiek**] en zijn voorzien van de nodige documentatie in de code repositories op GitHub: https://github.com/digipolisantwerp/acpaas-ui_angular [**publiek**] en https://github.com/digipolisantwerp/acpaas-ui_react [**publiek**]. Daarnaast zijn er examples beschikbaar van de componenten: https://digipolisantwerp.github.io/acpaas-ui_angular/ [**publiek**] en https://digipolisantwerp.github.io/acpaas-ui_react/ [**publiek**]. Wil je meer weten over het gebruik van deze componentenbibliotheek, bezoek dan de ACPaaS UI website: https://acpaas-ui.digipolis.be [**publiek**].
 
-Het gebruik van **ESLint** is verplicht, de parameters worden door Digipolis voorzien.
-
-#### 2.2.4. Angular component bibliotheek (**V**)
-Er is een gebruiksklare bibliotheek beschikbaar met de meestgebruikte UI componenten in de laatste stabiele Angular versie. Alle componenten worden gepubliceerd op https://nexusrepo.antwerpen.be [**VPN**] en zijn voorzien van de nodige documentatie in de code repositories op Bitbucket: https://bitbucket.antwerpen.be/projects/AUI [**VPN**]. Daarnaast zijn er examples beschikbaar van de componenten: https://bitbucket.antwerpen.be/projects/AUI/repos/examples/browse [**VPN**]. Wil je meer weten over het gebruik van deze componentenbibliotheek, bezoek dan de ACPaaS UI website (https://acpaas-ui.digipolis.be/ [**publiek**]).
+Om het werk van ontwerpers te vereenvoudigen is een bibliotheek van ontwerpelementen overeenstemmend met deze componenten ter beschikking gesteld. Meer hierover is te vinden op de ACPaaS UI website: https://acpaas-ui.digipolis.be/docs/design [**publiek**].
 
 Verdere specifieke componenten en service libraries moeten door de partner voorzien worden en toegevoegd aan de ACPaaS front-end bibliotheek conform de technische guidelines:
 
 - De componenten worden app-onafhankelijk gemaakt zodat ze herbruikbaar zijn in andere projecten/apps.
 - Release management: de componenten worden geversioneerd via **semantic versioning**.
-- De bibliotheek wordt beheerd via een specifiek Bitbucket project, waarbinnen elke component en service library een aparte repository vormt.
-- Alle componenten worden gepubliceerd via **Nexus**.
+- Toevoegingen aan ACPaaS UI volgen de contributierichtlijnen voor Angular en React, te vinden in de relevante repositories.
+- Componenten zijn bij voorkeur Open Source onder een MIT licentie en gepubliceerd op de open npmjs.com repository.
 - De code wordt via peer reviews van de front-end ontwikkelaars en/of technische architecten gevalideerd.
 
 Belangrijk: *het staat de partner vrij om een oplossing in een ander front-end framework voor te stellen. De partner is dan wel verplicht om de benodigde front-end componenten op een kwaliteitsvolle manier toe te voegen in de front-end bibliotheek (cfr. technische guidelines zoals hierboven beschreven). Op deze manier zijn deze componenten herbruikbaar voor toekomstige oplossingen. In de onderhandelingen wordt samen bekeken of dit een realistische piste is.*


### PR DESCRIPTION
Het stukje over front-end werd aangepast aan de veranderingen als gevolg van het ACPaaS UI vNext traject: de vernieuwde repositories, de designresources, de aangepaste website. Ook zijn er wat niet meer relevante vereisten verwijderd.